### PR TITLE
Distribute schema files as a python package

### DIFF
--- a/marvel_proto_events/__init__.py
+++ b/marvel_proto_events/__init__.py
@@ -1,0 +1,1 @@
+from marvel_proto_events import schema

--- a/marvel_proto_events/schema.py
+++ b/marvel_proto_events/schema.py
@@ -1,0 +1,34 @@
+from os import path, walk
+import json
+
+
+base = path.dirname(path.dirname(path.abspath(__file__)))
+
+
+def load_json_file(fname):
+    fpath = path.join(base, fname)
+    with open(fpath) as f:
+        return json.loads(f.read())
+
+
+def walk_directory_files(dir_path):
+    dirpath, dirnames, fnames = next(walk(dir_path))
+    for fname in fnames:
+        yield path.join(dirpath, fname)
+
+
+def load_json_files(directory_path):
+    files = {}
+    for fpath in walk_directory_files(directory_path):
+        if not fpath.endswith('.json'):
+            continue
+
+        type_key = path.basename(fpath).split('.', 1)[0]
+        files[type_key] = load_json_file(fpath)
+    return files
+
+
+event = load_json_file(path.join(base, 'event.json'))
+triggers = load_json_files(path.join(base, 'triggers'))
+objects = load_json_files(path.join(base, 'objects'))
+outcomes = load_json_files(path.join(base, 'outcomes'))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import setuptools
+
+# with open("README.md", "r") as fh:
+#     long_description = fh.read()
+
+setuptools.setup(
+    name="marvel-proto-events",
+    version="0.0.1",
+    author="Marvel Prototyping",
+    author_email="joe.alcorn@marvelapp.com",
+    description="Proto events",
+    url="https://github.com/marvelapp/prototype-event-schema",
+    packages=setuptools.find_packages(),
+    package_data={
+        '': [
+            'triggers/*.json',
+            'objects/*.json',
+            'outcomes/*.json',
+            'events.json',
+        ]
+    },
+    classifiers=[
+        "Private :: No Upload",
+    ],
+)


### PR DESCRIPTION
This lets us pip install the schema files for use in python projects.
I expect we'll do something similar for NPM when we need that