### PR TITLE
Drop `screen` from goalReached outcome - covered by `object` key

### DIFF
--- a/outcomes/goalReached.json
+++ b/outcomes/goalReached.json
@@ -5,8 +5,7 @@
   "type": "object",
   "title": "The Root Schema",
   "required": [
-    "type",
-    "screen"
+    "type"
   ],
   "properties": {
     "type": {
@@ -20,15 +19,6 @@
         "goalReached"
       ],
       "pattern": "^(.*)$"
-    },
-    "screen": {
-      "$id": "#/properties/screen",
-      "type": "integer",
-      "title": "The Screen Schema",
-      "description": "The PK of the goal screen that has been reached",
-      "examples": [
-        1587
-      ]
     }
   }
 }

--- a/validate.js
+++ b/validate.js
@@ -204,7 +204,6 @@ assertValid(
 assertValid(
     {
         type: 'goalReached',
-        screen: 1888,
     },
     require('./outcomes/goalReached.json')
 );


### PR DESCRIPTION
As title says, having a `screen` key in the goalReached outcome is redundant as that info is better conveyed using the event's `object` key