### PR TITLE
feat: add TypeScript schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,11 @@
   "dependencies": {
     "ajv": "^6.9.1",
     "flakeid": "^0.3.1"
+  },
+  "devDependencies": {
+    "prettier": "^3.0.3"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/schema.ts
+++ b/schema.ts
@@ -1,0 +1,184 @@
+type Animation =
+  | 'fade'
+  | 'push-left'
+  | 'push-right'
+  | 'slide-up'
+  | 'slide-down'
+  | 'slide-left'
+  | 'slide-right'
+  | 'pop'
+  | 'flip'
+  | 'flow'
+  | 'slide-fade'
+  | null;
+
+/**
+ * Globally unique ID for the test
+ */
+type EventId = string;
+
+export interface RootSchema {
+  trigger: Trigger;
+  object: Object;
+  outcome: Outcome;
+  id: EventId;
+  prevId: EventId | null;
+  /**
+   * Timestamp of the event relative to the start of the prototype-viewer session, in ms
+   */
+  timestamp: number;
+  [k: string]: unknown;
+}
+
+/**
+ * The object that was used in triggering this event, such as a hotspot or a screen
+ */
+export type Object =
+  | {
+      type: 'hotspot' | 'overlay' | 'scrollContainer';
+      id: number;
+    }
+  | {
+      type: 'player';
+    }
+  | {
+      type: 'screen';
+      id: number;
+      width: number;
+      height: number;
+    };
+/**
+ * An action that has happened as a result of this event occuring
+ */
+export type Outcome =
+  | {
+      type: 'goalReached' | 'miss' | 'startRecording' | 'stopRecording';
+    }
+  | {
+      type: 'openUrl';
+      url: string;
+      newWindow: boolean;
+    }
+  | {
+      type: 'overlayTransition';
+      /**
+       * The PK of the screen that is being overlain onto the currently active screen
+       */
+      screen: number;
+      /**
+       * The top left of the overlain screen
+       */
+      position: Coordinates;
+      /**
+       * The x,y coordinates of the scroll position
+       */
+      scrollPosition: Coordinates;
+      /**
+       * The animation used for the transition
+       */
+      animation: Animation;
+      /**
+       * Whether to reverse the animation or not
+       */
+      reverseAnimation: boolean;
+    }
+  | {
+      type: 'removeOverlay';
+      /**
+       * The PK of the screen that is under the currently active overlay
+       */
+      screen: number;
+      /**
+       * The animation used for the transition
+       */
+      animation: Animation;
+      /**
+       * Whether to reverse the animation or not
+       */
+      reverseAnimation: boolean;
+    }
+  | {
+      type: 'screenTransition';
+      /**
+       * The PK of the screen that transitioned to
+       */
+      screen: number;
+      /**
+       * The x,y coordinates of the scroll position
+       */
+      scrollPosition: Coordinates;
+      /**
+       * The animation used for the transition
+       */
+      animation: Animation;
+      /**
+       * Whether to reverse the animation or not
+       */
+      reverseAnimation: boolean;
+    }
+  | {
+      type: 'resize';
+      width: number;
+      height: number;
+    }
+  | {
+      type: 'scroll';
+      /**
+       * The PK of the screen that scrolled
+       */
+      screen: number | null;
+      /**
+       * The PK of the overlay that scrolled
+       */
+      overlay: number | null;
+      /**
+       * The x,y coordinates of the final scroll position
+       */
+      coords: Coordinates;
+      /**
+       * Whether to scroll smoothly or not
+       */
+      smooth: boolean;
+    };
+
+/**
+ * The x,y coordinates of the interaction
+ */
+type Coordinates = [number, number];
+
+/**
+ * What caused the event to happen, such as user interaction or an elapsed timer
+ */
+type Trigger =
+  | {
+      type: 'tap' | 'doubletap' | 'mousemove';
+      coords: Coordinates;
+    }
+  | {
+      type: 'navigation' | 'player' | 'timer' | 'user';
+    }
+  | {
+      type: 'pinch';
+      /**
+       * The direction of the pinch, either in or out
+       */
+      direction: 'in' | 'out';
+      coords: Coordinates;
+      duration: number;
+    }
+  | {
+      type: 'swipe';
+      /**
+       * The general direction of the swipe
+       */
+      direction: 'left' | 'right' | 'up' | 'down';
+      /**
+       * The x,y coordinate of the starting position for the swipe
+       */
+      startCoords: Coordinates;
+      /**
+       * The x,y coordinate of the ending position for the swipe
+       */
+      endCoords: Coordinates;
+      duration: number;
+    };

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"


### PR DESCRIPTION
I've started the process of extracting a TypeScript schema for prototype events, utilising the JSON Schema as the source of truth.

Currently, prototype events are typed as `any` within the `mkiii` mono repo, making it challenging to work with them in functions. Moreover, the JSON Schema is quite verbose and complex to understand (~180 lines are equivalent to the other 25 JSON files in the repository).

Ideally we should consider transitioning to TypeScript as the primary source of truth, similar to how we validate user test data within the mono repo. However, given that we have a Python package in the repository, we could also consider keeping TypeScript as our source of truth and create a script to generate the JSON schema when needed.